### PR TITLE
addon files need to be synchronised (hourly)

### DIFF
--- a/automatic.crontab
+++ b/automatic.crontab
@@ -34,6 +34,9 @@ poStatusHtml=/home/nvdal10n/ikiwiki/publish/poStatus.html
 # Keep live crontab in sync with version control.
 1 * * * * cd ${PathToMrRepo} && git pull -q && crontab automatic.crontab
 
+# Keep addonFiles in sync with version control.
+1 * * * * cd ${PathToMrRepo}/addons/addonFiles && git pull -q
+
 #x  1 for addons starting with a
 00  1 * * fri cd ${PathToMrRepo}/addons/addonUpdater && chronic mr addon2svn && chronic mr svn2addon
 03  1 * * fri cd ${PathToMrRepo}/addons/addonsHelp && chronic mr addon2svn && chronic mr svn2addon


### PR DESCRIPTION
Fixes #12 

Previously when the crontab file was synchronised, the addon-files were also synchronised. By moving the crontab file to this repo and synchronising with it instead, the addon files were not being updated.

This change introduces a dedicated entry to update the addonFiles.