### PR TITLE
document crontab failure notification

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -46,3 +46,7 @@ The following are the entry points to the translations system ccode:
   - mr svn2addon
 - via assembla webhook
  - python scripts/webhook
+
+## Notifications
+When a crontab command fails an email is sent to the nvdal10n account.
+Which is forwarded to the addresses listed in `~/.forward`


### PR DESCRIPTION
When a command in the automatic.crontab file fails, an email is sent. These emails are then forwarded on.

It would be good if this system didn't require access to the server to update, and recipients had more control. For now, just document how it works.