### PR TITLE
Use nvaccess addonFiles repo

### DIFF
--- a/.sh.d/00_github.sh
+++ b/.sh.d/00_github.sh
@@ -9,3 +9,15 @@ getGithubURL() {
     fi
     echo ${uri}/${name}.git
 }
+
+getNVAccessGithubURL() {
+    name=$(basename $MR_REPO)
+    if [ "$1" != "" ]; then
+        name="$1"
+    fi
+    uri="https://github.com/nvaccess"
+    if [ "$MR_USE_PROTOCOL" = "ssh" ]; then
+        uri="git@github.com:nvaccess"
+    fi
+    echo ${uri}/${name}.git
+}

--- a/available.d/10_addonFiles
+++ b/available.d/10_addonFiles
@@ -1,2 +1,2 @@
 [addons/addonFiles]
-checkout = git clone $(getGithubURL) $MR_REPO 
+checkout = git clone $(getNVAccessGithubURL) $MR_REPO


### PR DESCRIPTION
Rather than pull straight from nvdaAddons/addonFiles, ensure that changes get reviewed by NVAccess before they are copied to the server.

Note: 
- [ ] Update origin for the addonFiles repo on the server.