### PR TITLE
auto add dir for new Po

### DIFF
--- a/.sh.d/01_addon2svn.sh
+++ b/.sh.d/01_addon2svn.sh
@@ -21,7 +21,7 @@ _addFreshPoFile() {
     cp /tmp/${addonName}.pot ${addonPoPath}
     sed -i -e "s/Language: /Language: $lang/g" ${addonPoPath}
     msgmerge --no-location -U ${addonPoPath} /tmp/${addonName}-merge.pot
-    svn add ${addonPoPath}
+    svn add --parents ${addonPoPath}
     svn commit -m "${lang}: ${addonName} ready to be translated."  ${addonPath}
 }
 


### PR DESCRIPTION
A folder may exist in the working dir on server, but not in the repo.
In this case also auto-add parent directories to svn for the new po file.


@michaelDCurran This is an extension of #18 and has already been tested on the server, I'm going to go ahead and merge it. I have tagged you as a reviewer just as an FYI.