### PR TITLE
fix var substitution cron

### DIFF
--- a/automatic.crontab
+++ b/automatic.crontab
@@ -22,8 +22,9 @@
 # m h  dom mon dow   command
 PATH=/home/nvdal10n/bin:/usr/local/bin:/usr/bin:/bin
 PathToMrRepo=/home/nvdal10n/mr
-AddonTranslationUpdate="${PathToMrRepo}/scripts/addonTranslationUpdates.sh"
-NVDATranslationUpdate="${PathToMrRepo}/scripts/nvdaTranslationUpdates.sh"
+AddonTranslationUpdate="/home/nvdal10n/mr/scripts/addonTranslationUpdates.sh"
+NVDATranslationUpdate="/home/nvdal10n/mr/scripts/nvdaTranslationUpdates.sh"
+
 00  0 * * fri $NVDATranslationUpdate
 
 srt_scripts=/home/nvdal10n/mr/srt/scripts/


### PR DESCRIPTION
Cron jobs failed due to not being able to find the scripts.
This seems to be a limitation about expanding variables that contain other variables.
Instead specify the full path for the scripts.