### PR TITLE
Fix assembla web hook failure

### DIFF
--- a/automatic.crontab
+++ b/automatic.crontab
@@ -22,6 +22,7 @@
 # m h  dom mon dow   command
 PATH=/home/nvdal10n/bin:/usr/local/bin:/usr/bin:/bin
 PathToMrRepo=/home/nvdal10n/mr
+PathToCGI=/home/nvdal10n/cgi/
 AddonTranslationUpdate="/home/nvdal10n/mr/scripts/addonTranslationUpdates.sh"
 NVDATranslationUpdate="/home/nvdal10n/mr/scripts/nvdaTranslationUpdates.sh"
 
@@ -33,6 +34,9 @@ poStatusHtml=/home/nvdal10n/ikiwiki/publish/poStatus.html
 
 # Keep live crontab in sync with version control.
 1 * * * * cd ${PathToMrRepo} && git pull -q && crontab automatic.crontab
+
+# Ensure webhooks stay up to date.
+3 * * * * cp ${PathToMrRepo}/hooks/ ${PathToCGI}
 
 # Keep addonFiles in sync with version control.
 1 * * * * cd ${PathToMrRepo}/addons/addonFiles && git pull -q

--- a/docs/design.md
+++ b/docs/design.md
@@ -45,7 +45,8 @@ The following are the entry points to the translations system ccode:
   - mr addon2svn
   - mr svn2addon
 - via assembla webhook
- - python scripts/webhook
+  - hooks/webhook  
+  - python scripts/webhook
 
 ## Notifications
 When a crontab command fails an email is sent to the nvdal10n account.

--- a/hooks/webhook
+++ b/hooks/webhook
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 
 import sys

--- a/hooks/webhook
+++ b/hooks/webhook
@@ -1,0 +1,9 @@
+
+#!/usr/bin/env python3
+
+import sys
+
+sys.path.append('../mr/scripts')
+
+with open('../mr/scripts/webhook', 'r') as f:
+        exec(f.read(), {}, {})

--- a/scripts/poChecker.py
+++ b/scripts/poChecker.py
@@ -146,6 +146,7 @@ class PoChecker(object):
 	RE_UNNAMED_PERCENT = re.compile(r"(?<!%)%[.\d]*[a-zA-Z]")
 	RE_NAMED_PERCENT = re.compile(r"(?<!%)%\([^(]+\)[.\d]*[a-zA-Z]")
 	RE_FORMAT = re.compile(r"(?<!\{)\{([^{}:]+):?[^{}]*\}")
+
 	def _getInterpolations(self, text):
 		unnamedPercent = self.RE_UNNAMED_PERCENT.findall(text)
 		namedPercent = set(self.RE_NAMED_PERCENT.findall(text))
@@ -228,6 +229,7 @@ class PoChecker(object):
 		report += "\n\n" + "\n\n".join(self.alerts)
 		return report
 
+
 def main():
 	if len(sys.argv) <= 1:
 		sys.exit("Usage: %s poFile ...")
@@ -235,10 +237,12 @@ def main():
 	for fn in sys.argv[1:]:
 		c = PoChecker(fn)
 		if not c.check():
-			print(c.getReport().encode("UTF-8") + "\n\n")
+			report = c.getReport() + "\n\n"
+			print(report.encode("UTF-8"))
 		if c.errorCount > 0:
 			exitCode = 1
 	return exitCode
+
 
 if __name__ == "__main__":
 	sys.exit(main())


### PR DESCRIPTION
It seems like the `~/cgi/webhook` file was missed when updating to Python 3. I have now included it in this repo. Once that was in place it became clear there were errors in the `scripts/webhook` file. This has also been updated.

Now the `hooks/webhook` file is included in the repository, it is copied to the `cgi` folder automatically by crontab. Using crontab in this way is consistent with the rest of this repository.