### PR TITLE
Fix CGI Response

### DIFF
--- a/hooks/webhook
+++ b/hooks/webhook
@@ -6,6 +6,9 @@ import subprocess
 import os
 from datetime import datetime
 
+print("Content-type: text/plain\n")
+print("starting")
+
 logging.basicConfig(
 	# This process is run as user nvdal10n, which does not have write permissions for
 	# /var/log/uwsgi/app/ so instead of writing to file, write to stderr.
@@ -49,3 +52,4 @@ except Exception as e:
 
 endDate = datetime.now().strftime("%Y-%b-%d %H:%M:%S")
 logging.info(f"Webhook finished: {endDate}")
+print("ok")

--- a/scripts/webhook
+++ b/scripts/webhook
@@ -17,9 +17,6 @@ os.environ["PATH"] = "/home/nvdal10n/bin:/usr/local/bin:" + os.environ["PATH"]
 
 form = cgi.FieldStorage() # instantiate only once!
 
-print("Content-type: text/plain\n")
-
-
 author = form['author'].value if 'author' in form else 'pratchett'
 action = form['action'].value if 'action' in form else 'wrote'
 body = form['body'].value if 'body' in form else 'the colour of magic'

--- a/scripts/webhook
+++ b/scripts/webhook
@@ -94,7 +94,7 @@ email(rcpts, subject, body, includeAdmin=hasAlert)
 print("Notification sent.")
 
 rawData= "\n".join(
-    [f"{key}='{form[key].value}'n" for key in form.keys()]
+    [f"{key}='{form[key].value}'" for key in form.keys()]
 )
 print(f"""--- start ---
 rcpts: {", ".join(rcpts)}


### PR DESCRIPTION
Assembla disabled our webhook after many 502 responses.
502 comes from Nginx, after it fails to get a response from the CGI webhook.

When output of scripts was collected for logging, a line to specify the response type was included.
This response type has now been moved, so that it again reaches standard out.

