### PR TITLE
Add dropbox add-on which is not registered anymore even if still listed on addons.nvda-project.org

### DIFF
--- a/automatic.crontab
+++ b/automatic.crontab
@@ -60,6 +60,7 @@ poStatusHtml=/home/nvdal10n/ikiwiki/publish/poStatus.html
 #x  4 for addons starting with d
 00  4 * * fri $AddonTranslationUpdate dayOfTheWeek
 02  4 * * fri $AddonTranslationUpdate debugHelper
+04  4 * * fri $AddonTranslationUpdate dropbox
 
 #x  5 for addons starting with e
 00  5 * * fri $AddonTranslationUpdate emoticons

--- a/available.d/10_dropbox
+++ b/available.d/10_dropbox
@@ -1,0 +1,2 @@
+[addons/dropbox]
+checkout = git clone $(getGithubURL) $MR_REPO


### PR DESCRIPTION
It looks like there have been a moment where the repository location of the Dropbox add-on was not known.
This PR fixes this as the location is sure, on Github and add Dropbox to automatic.crontab and to available addons for translation.
