### PR TITLE
Incrementally log from webhook

### DIFF
--- a/.sh.d/01_addon2svn.sh
+++ b/.sh.d/01_addon2svn.sh
@@ -67,6 +67,8 @@ addon2svn() {
             _addFreshPoFile ${addonName} ${lang}
         else
             logMsg "Already available for translation, merging in new messages."
+            logMsg "svn status"
+            svn status ${addonPath}
 
             # Statistics before merging pot.
             bfuzzy=$(pocount ${addonPoPath} | grep -i fuzzy | awk '{print $2}')
@@ -81,9 +83,11 @@ addon2svn() {
             amsg="$afuzzy fuzzy and $auntranslated untranslated"
 
             if [ "$bmsg" != "$amsg" ]; then
+                logMsg "committing changes"
                 # need to commit, because before and after are different.
                 svn commit -m "${lang}: ${addonName} merged in ${amsg} messages"  ${addonPoPath}
             else
+                logMsg "reverting changes"
                 # nothing has changed, dont need to action.
                 # revert because comments/timestamps in po file might have changed.
                 svn revert ${addonPoPath}

--- a/hooks/webhook
+++ b/hooks/webhook
@@ -50,7 +50,7 @@ try:
 		logging.debug(line)
 except Exception as e:
 	logging.error(f"Error running scripts\\webhook process: {e}")
-logging.error(f"finished scripts\\webhook")
+logging.debug(f"finished scripts\\webhook")
 endDate = datetime.now().strftime("%Y-%b-%d %H:%M:%S")
 logging.info(f"Webhook finished: {endDate}")
 print("ok")

--- a/hooks/webhook
+++ b/hooks/webhook
@@ -22,34 +22,35 @@ logging.info(f"Webhook starting: {startDate}")
 
 SCRIPTS_PATH = os.path.abspath('../mr/scripts')
 
-try:
+def executeScriptsWebhook():
+	cmd = (os.path.join(SCRIPTS_PATH, "webhook"))
 	proc = subprocess.Popen(
-		(os.path.join(SCRIPTS_PATH, "webhook")),
+		cmd,
 		cwd=SCRIPTS_PATH,
 		stdout=subprocess.PIPE,
-		stderr=subprocess.PIPE,
+		stderr=subprocess.STDOUT,
 		errors="UTF-8",
 		encoding="UTF-8",
 	)
+
 	# https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen.stderr
 	#  If the encoding or errors arguments were specified or the universal_newlines argument was True,
 	#  the stream is a text stream, otherwise it is a byte stream. If the stderr argument was not PIPE,
 	#  this attribute is None.
-	WAIT_MINUTES = 5
-	MINUTE_SECONDS = 60
-	try:
-		outs, errs = proc.communicate(timeout=MINUTE_SECONDS * WAIT_MINUTES)
-	except subprocess.TimeoutExpired:
-		logging.error("TimeoutExpired. Process Killed.")
-		proc.kill()
-		outs, errs = proc.communicate()
-	logging.debug(f"scripts\\webHook:\n{outs}")
-	if errs:
-		logging.error(f"scripts\\webhook:\n{errs}")
+	for stdout_line in proc.stdout:
+		yield stdout_line
+	proc.stdout.close()
+	return_code = proc.wait()
+	if return_code:
+		raise subprocess.CalledProcessError(return_code, cmd)
 
+try:
+	logging.debug(f"starting scripts\\webHook")
+	for line in executeScriptsWebhook():
+		logging.debug(line)
 except Exception as e:
-	logging.error(f"Error running process: {e}")
-
+	logging.error(f"Error running scripts\\webhook process: {e}")
+logging.error(f"finished scripts\\webhook")
 endDate = datetime.now().strftime("%Y-%b-%d %H:%M:%S")
 logging.info(f"Webhook finished: {endDate}")
 print("ok")

--- a/scripts/findRevs.py
+++ b/scripts/findRevs.py
@@ -19,6 +19,7 @@ Should be run with working directory set to SRT directory
 logging.basicConfig(filename='findRevs.log',
     level=logging.DEBUG,
     format='%(asctime)s - %(levelname)s - %(message)s')
+logging.debug(f"args: {sys.argv}")
 
 parser = argparse.ArgumentParser(description='language processor.')
 #parser.add_argument('--type', required=True, choices=('ug', 'ch', 'sy'))
@@ -46,6 +47,7 @@ linfo = {
 }
 _wdiff = wdiff['-w', '-{', '-x', '}-', '-y', '+{', '-z', '}+', '-d']
 for lang in args.langs:
+    logging.debug(f"lang: {lang}")
     settingsPath = tbpath.join(lang).join('settings')
     try:
         mySettings = DB(settingsPath._path)


### PR DESCRIPTION
The webhook is periodically encoutering (what look like) time out errors. In these cases, the webhook process gets killed and no logging is written to the log. This change intends to incrementally log (both stdout and stderr) as the webhook process runs. Hopefully this allows us to see what the process is doing in these timeout situations.

