### PR TITLE
Fix incremental log for webhook

### DIFF
--- a/hooks/webhook
+++ b/hooks/webhook
@@ -1,4 +1,6 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -u
+# -S allows for arguments
+# -u unbuffered output
 
 import sys
 import logging

--- a/hooks/webhook
+++ b/hooks/webhook
@@ -39,9 +39,12 @@ def executeScriptsWebhook():
 	#  this attribute is None.
 	for stdout_line in proc.stdout:
 		yield stdout_line
+	logging.debug("No more stdout")
 	proc.stdout.close()
+	logging.debug("waiting for proc")
 	return_code = proc.wait()
 	if return_code:
+		logging.debug("Called Process Error")
 		raise subprocess.CalledProcessError(return_code, cmd)
 
 try:

--- a/hooks/webhook
+++ b/hooks/webhook
@@ -24,7 +24,8 @@ SCRIPTS_PATH = os.path.abspath('../mr/scripts')
 
 def executeScriptsWebhook():
 	cmd = (os.path.join(SCRIPTS_PATH, "webhook"))
-	proc = subprocess.Popen(
+	logging.debug(f"Running: {cmd}")
+	proc: subprocess.Popen = subprocess.Popen(
 		cmd,
 		cwd=SCRIPTS_PATH,
 		stdout=subprocess.PIPE,
@@ -32,13 +33,13 @@ def executeScriptsWebhook():
 		errors="UTF-8",
 		encoding="UTF-8",
 	)
-
+	logging.debug("Start logging output from proc")
 	# https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen.stderr
 	#  If the encoding or errors arguments were specified or the universal_newlines argument was True,
 	#  the stream is a text stream, otherwise it is a byte stream. If the stderr argument was not PIPE,
 	#  this attribute is None.
 	for stdout_line in proc.stdout:
-		yield stdout_line
+		logging.debug( stdout_line)
 	logging.debug("No more stdout")
 	proc.stdout.close()
 	logging.debug("waiting for proc")
@@ -49,8 +50,7 @@ def executeScriptsWebhook():
 
 try:
 	logging.debug(f"starting scripts\\webHook")
-	for line in executeScriptsWebhook():
-		logging.debug(line)
+	executeScriptsWebhook()
 except Exception as e:
 	logging.error(f"Error running scripts\\webhook process: {e}")
 logging.debug(f"finished scripts\\webhook")

--- a/hooks/webhook
+++ b/hooks/webhook
@@ -34,6 +34,7 @@ def executeScriptsWebhook():
 		encoding="UTF-8",
 		bufsize=0,
 	)
+	logging.info(f"Proc pid: {proc.pid}")
 	logging.debug("Start logging output from proc")
 	# https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen.stderr
 	#  If the encoding or errors arguments were specified or the universal_newlines argument was True,

--- a/hooks/webhook
+++ b/hooks/webhook
@@ -32,6 +32,7 @@ def executeScriptsWebhook():
 		stderr=subprocess.STDOUT,
 		errors="UTF-8",
 		encoding="UTF-8",
+		bufsize=0,
 	)
 	logging.debug("Start logging output from proc")
 	# https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen.stderr

--- a/scripts/webhook
+++ b/scripts/webhook
@@ -1,4 +1,6 @@
-#!/usr/bin/python3
+#!/usr/bin/env -S python3 -u
+# -S allows for arguments
+# -u unbuffered output
 
 print("imports")
 import os

--- a/scripts/webhook
+++ b/scripts/webhook
@@ -15,6 +15,7 @@ SCRIPTS_PATH = "/home/nvdal10n/mr/scripts"
 # Also add /usr/local/bin, which isn't already included in this context.
 os.environ["PATH"] = "/home/nvdal10n/bin:/usr/local/bin:" + os.environ["PATH"]
 
+print("load cgi field storage")
 form = cgi.FieldStorage() # instantiate only once!
 
 author = form['author'].value if 'author' in form else 'pratchett'

--- a/scripts/webhook
+++ b/scripts/webhook
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+print("imports")
 import os
 import cgi
 import re


### PR DESCRIPTION
Adds a number of extra details to the logging. The reason logs weren't being captured is because the output was being buffered.
The scripts are run relying on the shebang (!#) to specify the interpreter. The option to run unbuffered must be specified with the shebang.
