### PR TITLE
Remove afik.sofer@gmail.com as a translator

### DIFF
--- a/scripts/addressData.py
+++ b/scripts/addressData.py
@@ -172,7 +172,6 @@ addresses = {
 		'lang': 'Hebrew',
 		'email': [
 			'Shmuel Naaman <shmuel_naaman@yahoo.com>',
-			'Afik Sofir <afik.sofer@gmail.com>',
 		],
 	},
 	'hi': {


### PR DESCRIPTION
The email address bounces back, and appears to be unreachable.
I've notified the other Hebrew translator of this pull request.