### PR TITLE
Fix key commands gen

### DIFF
--- a/scripts/keyCommandsDoc.py
+++ b/scripts/keyCommandsDoc.py
@@ -11,6 +11,8 @@
 import os
 import codecs
 import re
+import sys
+
 import txt2tags
 
 LINE_END = u"\r\n"
@@ -18,6 +20,9 @@ LINE_END = u"\r\n"
 class KeyCommandsError(Exception):
 	"""Raised due to an error encountered in the User Guide related to generation of the Key Commands document.
 	"""
+	def __init__(self, message):
+		self.message = message
+		super().__init__(message)
 
 class KeyCommandsMaker(object):
 	"""Generates the Key Commands document from the User Guide.
@@ -283,3 +288,15 @@ class KeyCommandsMaker(object):
 			os.remove(self.kcFn)
 		except OSError:
 			pass
+
+if __name__ == "__main__":
+	f = KeyCommandsMaker(
+		userGuideFilename='userGuide.t2t',
+		keyCommandsFileName='keyCommands.html'
+	)
+	try:
+		result = f.make()
+		if not result:
+			sys.exit("User Guide does not contain key commands markup")
+	except KeyCommandsError as e:
+		sys.exit(e.message)

--- a/scripts/keyCommandsDoc.py
+++ b/scripts/keyCommandsDoc.py
@@ -292,7 +292,7 @@ class KeyCommandsMaker(object):
 if __name__ == "__main__":
 	f = KeyCommandsMaker(
 		userGuideFilename='userGuide.t2t',
-		keyCommandsFileName='keyCommands.html'
+		keyCommandsFileName='keyCommands.t2t'
 	)
 	try:
 		result = f.make()


### PR DESCRIPTION
When upgrading to Python 3, it looks like this file was copied directly from NVDA without reintroducing the `main` section.
This PR reintroduces the deleted `main` section and makes some changes required for Python 3.