### PR TITLE
Fix a name of the add-ons organization in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ This info is provided for convenience, according to discussions like this
 - Fetch the GitHub/nvdaaddons repo:
 	- `git fetch nvdaaddons`
 - Track the stable branch:
-	- `git checkout -t nvdaadons/stable`
+	- `git checkout -t nvdaaddons/stable`
 - Periodically:
 	- From stable branch:
 		- `git pull` # Get translations


### PR DESCRIPTION
The name of the NVDA  add-ons organization in the readme was misspelled nvdaadons instead of nvdaaddons.