### PR TITLE
add locale.t2tconf as a translatable file

### DIFF
--- a/.sh.d/01_nvda2svn.sh
+++ b/.sh.d/01_nvda2svn.sh
@@ -41,8 +41,8 @@ findRevs() {
     for lang in ${langs}; do
         logMsg "Processing ${lang}"
         ../scripts/findRevs.py --langs $lang
-        svn add -q --parents ${lang}/settings ${lang}/userGuide-newRevisions/* ${lang}/changes-newRevisions/* ${lang}/symbols-newRevisions/* || 
-        svn commit -m "${lang}: new revisions for translation." ${lang}/settings ${lang}/userGuide-newRevisions ${lang}/changes-newRevisions ${lang}/symbols-newRevisions ||
+        svn add -q --parents ${lang}/settings ${lang}/userGuide-newRevisions/* ${lang}/changes-newRevisions/* ${lang}/symbols-newRevisions/* ${lang}/locale-newRevisions/* || 
+        svn commit -m "${lang}: new revisions for translation." ${lang}/settings ${lang}/userGuide-newRevisions ${lang}/changes-newRevisions ${lang}/symbols-newRevisions ${lang}/locale-newRevisions ||
         logMsg "Error processing ${lang}"
     done
 }

--- a/.sh.d/01_svn2nvda.sh
+++ b/.sh.d/01_svn2nvda.sh
@@ -80,6 +80,7 @@ svn2nvda () {
         _cp $lang/gestures.ini source/locale/$lang/gestures.ini
 
         checkT2t $lang/changes.t2t && _cp $lang/changes.t2t  user_docs/$lang/changes.t2t
+        checkT2t $lang/locale.t2tconf && _cp $lang/locale.t2tconf  user_docs/$lang/locale.t2tconf
         checkUserGuide $lang && _cp $lang/userGuide.t2t  user_docs/$lang/userGuide.t2t
         commit=$(git -C "$gitDir" diff --cached | wc -l)
         if [ "$commit" -gt "0" ]; then

--- a/scripts/findRevs.py
+++ b/scripts/findRevs.py
@@ -34,6 +34,11 @@ linfo = {
         'srcpath': 'user_docs/en/changes.t2t',
         'dstprefix': 'changes-newRevisions',
     },
+    'locale': {
+        'filename': 'locale.t2tconf',
+        'srcpath': 'user_docs/en/locale.t2tconf',
+        'dstprefix': 'locale-newRevisions',
+    },
     'userGuide': {
         'filename': 'userGuide.t2t',
         'srcpath': 'user_docs/en/userGuide.t2t',


### PR DESCRIPTION
Closes nvaccess/nvda#14169
Relates to nvaccess/nvda#8856, and closes the issue with nvaccess/nvda#14546

`locale.t2tconf` allows translators to set the locale and layout direction of NVDA user documentation
`locale.t2tconf` files cannot be modified by translators, and are expected to be modified in the main NVDA repository.
This is an unexpected workflow for translators, they should be able to push changes to `locale.t2tconf`.

### Testing

What is the best way to test this script?
