### PR TITLE
Update github comment action, docs

### DIFF
--- a/.github/workflows/checkStableBranch.yaml
+++ b/.github/workflows/checkStableBranch.yaml
@@ -39,13 +39,7 @@ jobs:
         scons
         scons pot
     - name: Comment
-      uses: actions/github-script@v6
+      uses: peter-evans/create-or-update-comment@v2
       with:
-        script: |
-          github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: 'The add-on and pot files were built from stable branch'
-          })
-          
+        issue-number: ${{ github.event.issue.number }}
+        body: The add-on and pot files were built from stable branch

--- a/readme.md
+++ b/readme.md
@@ -4,9 +4,9 @@
 
 Used to manage translation updates for NVDA and NVDA add-ons.
 
-## Addon website
-For information on having add-ons added to the nvda-addons website:
-https://github.com/nvaccess/addonFiles#readme
+## Add-on store and website
+For information on having add-ons added to the NVDA add-on store and legacy nvda-addons website:
+https://github.com/nvaccess/addon-datastore/blob/master/docs/submitters/submissionGuide.md
 
 ## Translating your addon
 


### PR DESCRIPTION
As per comment here:
https://github.com/nvaccess/mrconfig/issues/86#issuecomment-1465150135

The github action we were using is deprecated. This has been updated.

The documentation has also been  to reference the new add-on repo, instead of the legacy one