### PR TITLE
only perform scons pot

### DIFF
--- a/.github/workflows/checkStableBranch.yaml
+++ b/.github/workflows/checkStableBranch.yaml
@@ -36,7 +36,6 @@ jobs:
         sudo apt install gettext
     - name: Build
       run: |
-        scons
         scons pot
     - name: Comment
       uses: actions/github-script@v6


### PR DESCRIPTION
The check action failed for this add-on: https://github.com/nvaccess/mrconfig/issues/89, https://github.com/nvaccess/mrconfig/actions/runs/4557071601

This is due to the check running `scons` causing a full build of the add-on.
We cannot build add-ons in the server ubuntu environment, as some dependencies such as windows headers are required to build add-ons.
The translation system only needs to run `scons pot` in `01_addon2svn.sh`.
As such, the full build is removed from the validation action