### PR TITLE
Fixed comment in checkStableBranch.yaml GitHub workflow after #90

### DIFF
--- a/.github/workflows/checkStableBranch.yaml
+++ b/.github/workflows/checkStableBranch.yaml
@@ -41,4 +41,4 @@ jobs:
       uses: peter-evans/create-or-update-comment@v2
       with:
         issue-number: ${{ github.event.issue.number }}
-        body: The pot files was built from stable branch
+        body: The pot files were built from the stable branch.

--- a/.github/workflows/checkStableBranch.yaml
+++ b/.github/workflows/checkStableBranch.yaml
@@ -41,4 +41,4 @@ jobs:
       uses: peter-evans/create-or-update-comment@v2
       with:
         issue-number: ${{ github.event.issue.number }}
-        body: The add-on and pot files were built from stable branch
+        body: The pot files was built from stable branch


### PR DESCRIPTION
In #90, the "scons" command was removed from the autoatic workflow, keeping only "scons pot". However, the associated comment generated in the action was not updated.

This PR updates the comment to avoid confusion.
