### PR TITLE
Add separate t2tconf file check

### DIFF
--- a/.sh.d/01_svn2nvda.sh
+++ b/.sh.d/01_svn2nvda.sh
@@ -35,11 +35,6 @@ checkT2tConf() {
         echo Encoding problem: $encoding
         return 1
     fi
-    if ! output=$(python3 /home/nvdal10n/mr/scripts/txt2tags.py -q -o /dev/null $1 2>&1); then
-        echo Error in $1:
-        echo "$output"
-        return 1
-    fi
 }
 
 checkUserGuide() {

--- a/.sh.d/01_svn2nvda.sh
+++ b/.sh.d/01_svn2nvda.sh
@@ -30,7 +30,7 @@ checkT2tConf() {
         echo Warning: $1 does not exist
         return 1
     fi
-    encoding=`file $1 | grep -vP ': +(HTML document, )?(PostScript document text)'`
+    encoding=`file $1 | grep -vP ': +(HTML document, )?(ASCII text|UTF-8|empty|PostScript document text)'`
     if [ "$encoding" != "" ]; then
         echo Encoding problem: $encoding
         return 1

--- a/.sh.d/01_svn2nvda.sh
+++ b/.sh.d/01_svn2nvda.sh
@@ -25,6 +25,23 @@ checkT2t() {
     fi
 }
 
+checkT2tConf() {
+    if [ ! -f $1 ]; then
+        echo Warning: $1 does not exist
+        return 1
+    fi
+    encoding=`file $1 | grep -vP ': +(HTML document, )?(PostScript document text)'`
+    if [ "$encoding" != "" ]; then
+        echo Encoding problem: $encoding
+        return 1
+    fi
+    if ! output=$(python3 /home/nvdal10n/mr/scripts/txt2tags.py -q -o /dev/null $1 2>&1); then
+        echo Error in $1:
+        echo "$output"
+        return 1
+    fi
+}
+
 checkUserGuide() {
     checkT2t $1/userGuide.t2t || return 1
     origDir=`pwd`
@@ -80,7 +97,7 @@ svn2nvda () {
         _cp $lang/gestures.ini source/locale/$lang/gestures.ini
 
         checkT2t $lang/changes.t2t && _cp $lang/changes.t2t  user_docs/$lang/changes.t2t
-        checkT2t $lang/locale.t2tconf && _cp $lang/locale.t2tconf  user_docs/$lang/locale.t2tconf
+        checkT2tConf $lang/locale.t2tconf && _cp $lang/locale.t2tconf  user_docs/$lang/locale.t2tconf
         checkUserGuide $lang && _cp $lang/userGuide.t2t  user_docs/$lang/userGuide.t2t
         commit=$(git -C "$gitDir" diff --cached | wc -l)
         if [ "$commit" -gt "0" ]; then


### PR DESCRIPTION
The `checkT2t` function was failing for t2tconf files, causing them not to be pushed to the NVDA beta branch.

Some `.t2tconf` files have a mimetype of `application/postscript` which is determined by the OS, not the file metadata.
As such, a different check is required for t2tconf files.

The text2tags processing is also not required for `t2tconf` files.

