### PR TITLE
Add support for ngettext

### DIFF
--- a/scripts/poChecker.py
+++ b/scripts/poChecker.py
@@ -69,18 +69,21 @@ class PoChecker(object):
 			msgType = "Fuzzy message"
 		else:
 			msgType = "Message"
-		self.alerts.append(u"{msgType} starting on line {lineNum}\n"
+		self.alerts.append(
+			(
+				"{msgType} starting on line {lineNum}\n"
 				'Original: "{msgid}"\n'
 				'Translated: "{msgstr}"\n'
 				"{alertType}: {alert}"
-			.format(
+			).format(
 				msgType=msgType,
 				lineNum=self._messageLineNum,
 				msgid=self._msgid,
 				msgstr=self._msgstr[-1],
 				alertType="Error" if isError else "Warning",
 				alert=alert,
-			))
+			)
+		)
 
 	def _checkSyntax(self):
 		p = subprocess.Popen((MSGFMT, "-o", "-", self._poPath),


### PR DESCRIPTION
### Links to issues:
Preliminary to https://github.com/nvaccess/nvda/issues/12445

### Context

A first use of ngettext had been introduced in NVDA in https://github.com/nvaccess/nvda/pull/11598 and https://github.com/nvaccess/nvda/pull/12432.
However these changes were removed in https://github.com/nvaccess/nvda/pull/12448.

### Issue
As written by @michaelDCurran in https://github.com/nvaccess/nvda/pull/12448:
> However, it seems that our PO validation code in the translation system is not handling plural forms well, and is incorrectly classing translations as missing brace format variables, as it is incorrectly comparing the translation with the message before that one.
> It then outputs the following error:
> Message starting on line 7169
> Original: "{startTime} to {endTime}"
> Translated: "category {categories}"
> Error: missing brace format interpolation, extra brace format interpolation
> Expected: these brace format interpolations: {endTime}, {startTime}
> Got: these brace format interpolations: {categories} 

### Changes in this PR
This PR adds the support of ngettext messages in the PO validation script.

### Tests
#### Test 1
Run new `scripts/poChecker.py` on various files:
* A complete recent (French) translation file with no issue: [nvda_OK.po.txt](https://github.com/nvaccess/mrconfig/files/11452461/nvda_OK.po.txt)
* A complete file with a plural string translated and no translation issue: [nvda-61403_OK_plural3_translated.po.txt](https://github.com/nvaccess/mrconfig/files/11452472/nvda-61403_OK_plural3_translated.po.txt)
* A file with plural string untranslated: 
[nvda-61397_NOK_plural2_untranslated.po.txt](https://github.com/nvaccess/mrconfig/files/11452482/nvda-61397_NOK_plural2_untranslated.po.txt)

The files containing the plural string have been taken from SVN SRT repo when a first attempt to introduce ngettext in NVDA was made.

### Test 2
Comparison of the output of the modified script with the output of the original one. The comparison has been made on the `nvda.po` files of all languages available in SVN repo screenreadertranslations (commit 74391) as well as with all the `nvda.po` files available in the last master version of NVDA's Git repo (commit 96764959510a19d390f4493b78510df3a353cd50).
The comparison has been made thanks to a test script made for this task.

Some diffs have been found in the order in which the placeholders are listed in the report, e.g.:
```
-Expected: these brace format interpolations: {hours:d}, {minutes:d}
+Expected: these brace format interpolations: {minutes:d}, {hours:d}
```

The placeholders are stored in a Python set in `scripts/poChecker.py`, thus their order is not significant. I do not know however why the order has changed from one version of `scripts/poChecker.py` to another.
Thus I have amended my test script to reorder alphabetically the placeholders in the output of `scripts/poChecker.py` so that we can ignore the order of placeholders on a same line.
After this reordering post-processing, there was no diff between the outputs of the old and the new version of the script.

For reference here is the (quick and dirty) test script that I have used (updated and re-tested on June 9 2023): 
[launch_poChecker.py.txt](https://github.com/nvaccess/mrconfig/files/11705752/launch_poChecker.py.txt)

