### PR TITLE
Update pot build command as per the one in NVDA's repo (update in PR NVDA/#15013)

### DIFF
--- a/.sh.d/01_nvda2svn.sh
+++ b/.sh.d/01_nvda2svn.sh
@@ -9,7 +9,7 @@ makePot() {
         --foreign-user \
         --add-comments=Translators: \
         --keyword=pgettext:1c,2 \
-        --keyword=npgettext:1c,2,3
+        --keyword=npgettext:1c,2,3 \
         --from-code utf-8 \
         --language=python \
         *.py *.pyw */*.py */*/*.py

--- a/.sh.d/01_nvda2svn.sh
+++ b/.sh.d/01_nvda2svn.sh
@@ -6,7 +6,10 @@ makePot() {
     version="beta-`git rev-parse --short beta`"
     xgettext -o $potName \
         --package-name NVDA --package-version "$version" \
-        --foreign-user --add-comments=Translators: --keyword=pgettext:1c,2 \
+        --foreign-user \
+        --add-comments=Translators: \
+        --keyword=pgettext:1c,2 \
+        --keyword=npgettext:1c,2,3
         --from-code utf-8 \
         --language=python \
         *.py *.pyw */*.py */*/*.py


### PR DESCRIPTION
### Issue
Today, the first version of NVDA including https://github.com/nvaccess/nvda/pull/15013 has been merged to SVN. The translatable strings using `ngettext` appear in the `nvda.po` as expected. But the strings using `npgettext` ("%.1f lignes") don't.

### Cause
In PR https://github.com/nvaccess/nvda/pull/15013, the command to build the .pot file has been updated to be able to recognize `npgettext` as a function operating on translatable strings.
However, the nvda2svn script in the current repository does not use the .pot generated by NVDA's `sconstruct`; xgettext is called directly in the current repository instead. Thus the command in the nvda2svn script should match the one in NVDA's sconstruct. The change in NVDA's repository had not been duplicated here.

### Solution
Update `xgettext`'s parameters as per what was done in NVDA's repo to be able to detect `ngettext` as a function operating on translatable strings.

### Testing
I have no way to test before merging this PR.

@seanbudd, could you test manually this branch on NVAccess server the result of nvda2svn script or merge this PR and trigger nvda2svn?
* The string "%.1f lignes" should appear in the .pot file with a "msgid_plural" field.
* Also the strings "category {categories}" and "with %s item" should still have the msgid_plural field (as today)

