### PR TITLE
Added one level when searching for .py files to construct the .pot file

### DIFF
--- a/.sh.d/01_nvda2svn.sh
+++ b/.sh.d/01_nvda2svn.sh
@@ -9,7 +9,7 @@ makePot() {
         --foreign-user --add-comments=Translators: --keyword=pgettext:1c,2 \
         --from-code utf-8 \
         --language=python \
-        *.py *.pyw */*.py */*/*.py
+        *.py *.pyw */*.py */*/*.py */*/*/*.py
     cd $origDir
     # Tweak the headers.
     sed -i '

--- a/.sh.d/01_nvda2svn.sh
+++ b/.sh.d/01_nvda2svn.sh
@@ -9,6 +9,7 @@ makePot() {
         --foreign-user --add-comments=Translators: --keyword=pgettext:1c,2 \
         --from-code utf-8 \
         --language=python \
+        # Unfortunately **/*.py doesn't work here
         *.py *.pyw */*.py */*/*.py */*/*/*.py
     cd $origDir
     # Tweak the headers.


### PR DESCRIPTION
Another issue found on the .pot generation

### Issue
Some strings of the add-on store GUI are not provided to translators as reported in [this message](https://groups.io/g/nvda-translations/message/3286).

### Cause
When generating the .pot file, svn2nvda looks for .py files only in NVDA's source folder and maximum two levels below. However, after merging of https://github.com/nvaccess/nvda/pull/13985, the GUI files of the add-on store are three levels below, thus they are not taken as source when generating the .pot file.

### Solution
Added one more level for the sources used by xgettext to generate the .pot file.

### Testing
* @seanbudd could you manually check the generated files on the server?
* Check after merge that the strings are provided to translators.


