### PR TITLE
Remove the address of former bn translator

### DIFF
--- a/scripts/addressData.py
+++ b/scripts/addressData.py
@@ -43,9 +43,7 @@ addresses = {
 	
 	'bn': {
 		'lang': 'Bangla',
-		'email': [
-			'Farhan Ishrak Fahim <fahim.net.2014@gmail.com>',
-		],
+		'email': [],
 	},
 	'bg': {
 		'lang': 'Bulgarian',


### PR DESCRIPTION
### Changes
As per his request in [this message](https://groups.io/g/nvda-translations/topic/srt_mail/100197903?p=,,,100,0,0,0::recentpostdate/sticky,,,100,2,0,100197903,previd%3D1689610440086203400,nextid%3D1653227474471096688&previd=1689610440086203400&nextid=1653227474471096688), removed farhan israk's e-mail address so that he does not receive any SRT notification.

He had already informed [here](https://groups.io/g/nvda-translations/topic/95585982#3145) that he had stepped down as a volunteer translator.

### Note
The list of bn translators becomes empty, and there is actually no Bangla translator today. I hope that empty list do not cause any issue during processing.

### Tests

After merging, please check that:
* modifications in the website folder is still working; it is usually sent to translators of all languages.
* if one day some file is committed in bn folder, e.g. for global modifications such as replacing http by https in all files, check that the scripts NVDA to SVN or SVN to NVDA still work.

