### PR TITLE
Updates for the structure diff scripts:

### DIFF
--- a/scripts/rebuildStats.sh
+++ b/scripts/rebuildStats.sh
@@ -2,13 +2,19 @@
 
 # Called by convertOne.sh, with current directory set to SRT_PATH/<lang>
 
-nextRev=`ls -1 userGuide-newRevisions/ | head -n 1`
-if [ "$nextRev" == "" ]; then
-    echo "No revision found, unable to calculate structure difference."
-    exit
-fi
-
 scriptsDir="../../scripts"
 lang=$(basename `pwd`)
 
+nextRev=`ls -1 changes-newRevisions/ | head -n 1`
+if [ "$nextRev" == "" ]; then
+    echo "No revision found, unable to calculate changes structure difference."
+    exit
+fi
+python3 ${scriptsDir}/structDiffMd.py $lang changes-newRevisions/$nextRev/changes.md changes.md changes-structureDifferences.txt
+
+nextRev=`ls -1 userGuide-newRevisions/ | head -n 1`
+if [ "$nextRev" == "" ]; then
+    echo "No revision found, unable to calculate userGuide structure difference."
+    exit
+fi
 python3 ${scriptsDir}/structDiffMd.py $lang userGuide-newRevisions/$nextRev/userGuide.md userGuide.md userGuide-structureDifferences.txt

--- a/scripts/structDiffMd.py
+++ b/scripts/structDiffMd.py
@@ -11,6 +11,7 @@ If no error is found, nothing is printed on the output.
 import sys
 import os
 import re
+from itertools import zip_longest
 
 # Set to True to check blank at end of line. It is currently disabled due to the high number of diffs in 
 # the change log (French)
@@ -22,7 +23,12 @@ CHECK_CODE_FORMATTING = True
 def structDiff(enFile, localeFile):
 	output = []
 	with open(enFile, encoding="utf8") as f1, open(localeFile, encoding="utf8") as f2:
-		for (nLine, (enLine, locLine)) in enumerate(zip(f1, f2)):
+		for (nLine, (enLine, locLine)) in enumerate(zip_longest(f1, f2)):
+			if enLine is None or locLine is None:
+				output.append(f'Line {nLine+1}: One of the files is shortest')
+				output.append(f'English = {repr(enLine)}')
+				output.append(f'Locale  = {repr(locLine)}')  # Double space for vertical alignment between both lines.
+				continue
 			err = compareLines(enLine, locLine)
 			if err is not None:
 				output.append(f'Line {nLine+1}: {err}')
@@ -138,4 +144,10 @@ if __name__ == '__main__':
 	else:
 		print("No differences found")
 		output = "No differences found"
-	open(outFile, 'w', encoding='utf-8').write(output)
+	compaInfo = f"Comparing {locale} {baseName} against English:\n"
+	compaInfo += f"English file: {enFile}\n"
+	compaInfo += f"Local file: {transFile}\n"
+	compaInfo += "\n"
+	with open(outFile, 'w', encoding='utf-8') as f:
+		f.write(compaInfo)
+		f.write(output)


### PR DESCRIPTION
Various updates for the diff script:

### Issues
1. Change log structure difference should also be checked in prevision of the migration to Crowdin. The script was capable to check the change log but it has not been enabled when it was introduced
2. In case no difference is found, it may not be clear for the user if the structure has been checked or not. See [this discussion](https://groups.io/g/nvda-translations/topic/106337272?p=Created,,,100,1,0,0) for example.
3. In case the two files being compared have not the same length, only the common part is being compared.

### Solutions:
1. Now also checks the diffs of the change log
2. Indicate the files being compared in the report as it was done in the old version of t2t comparison.
3. Use `itertools.zip_longest` instead of `zip` when reading the files content

### Tests
1. Not tested
2. and 3. Manual test locally on my Windows computer.

### Known issues
I have not been able to test 1. Please double check when committing on the server. Thanks.

Cc @michaelDCurran 
