### PR TITLE
Remove Add-on Updater from mrconfig

### DIFF
--- a/automatic.crontab
+++ b/automatic.crontab
@@ -45,7 +45,6 @@ poStatusHtml=/home/nvdal10n/ikiwiki/publish/poStatus.html
 1 * * * * cd ${PathToMrRepo}/addons/addonFiles && git pull -q
 
 #x  1 for addons starting with a
-00  1 * * fri $AddonTranslationUpdate addonUpdater
 03  1 * * fri $AddonTranslationUpdate addonsHelp
 05  1 * * fri $AddonTranslationUpdate audioChart
 10  1 * * fri $AddonTranslationUpdate audiothemes

--- a/available.d/10_addonUpdater
+++ b/available.d/10_addonUpdater
@@ -1,2 +1,0 @@
-[addons/addonUpdater]
-checkout = git clone $(getGithubURL) $MR_REPO

--- a/enabled.d/10_addonUpdater
+++ b/enabled.d/10_addonUpdater
@@ -1,1 +1,0 @@
-../available.d/10_addonUpdater


### PR DESCRIPTION
Closes #132 

This pull request removes Add-on Updater from localization exchange instructions - the add-on is in deep maintenance and will be discontinued soon.

Thanks.