### PR TITLE
Windows App Essentials (WintenApps): terminate localization data exchange

### DIFF
--- a/automatic.crontab
+++ b/automatic.crontab
@@ -160,7 +160,6 @@ poStatusHtml=/home/nvdal10n/ikiwiki/publish/poStatus.html
 # x 22 for addons starting with v or w
 00  22 * * fri $AddonTranslationUpdate VLC
 05  22 * * fri $AddonTranslationUpdate Weather_Plus
-10  22 * * fri $AddonTranslationUpdate wintenApps
 # 15  22 * * fri $AddonTranslationUpdate wordCount
 20  22 * * fri $AddonTranslationUpdate winMag
 25  22 * * fri $AddonTranslationUpdate winWizard

--- a/available.d/10_wintenApps
+++ b/available.d/10_wintenApps
@@ -1,2 +1,0 @@
-[addons/wintenApps]
-checkout = git clone $(getGithubURL) $MR_REPO

--- a/enabled.d/10_wintenApps
+++ b/enabled.d/10_wintenApps
@@ -1,1 +1,0 @@
-../available.d/10_wintenApps


### PR DESCRIPTION
Closes #137 

This PR removes Windows App Essentials from available add-ons list and from crontab. With this PR, Windows App Essentials add-on localization data exchange via Assembla/Subversion workflow is discontinued.

Thanks.